### PR TITLE
[SEMVER-MAJOR] Disable multiple empty lines

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -27,6 +27,7 @@
     "max-len": ["error", 80, 4, {"ignoreComments": true, "ignoreUrls": true,
       "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\("}],
     "no-array-constructor": 2,
+    "no-multiple-empty-lines": ["error", { "max": 1 }],
     "no-trailing-spaces": 2,
     "object-curly-spacing": ["error", "always", {
       "objectsInObjects": false,


### PR DESCRIPTION
Correct:

```
function a() {
}

function b() {
}
```

Incorrect:

```
function a() {
}


function b() {
}
```

This rule will also reject files that have more than one empty line at EOF.

@strongloop/loopback-dev please review.

Note that this is a breaking change, upgrading modules like loopback-datasource-juggler will require us to fix the coding style.
