### PR TITLE
[SEMVER-MAJOR] Disable unused expressions

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -7,6 +7,7 @@
     "comma-dangle": ["error", "always-multiline"],
     "no-cond-assign": "error",
     "no-console": "off",
+    "no-unused-expressions": "error",
 
     "array-bracket-spacing": ["error", "never"],
     "block-spacing": ["error", "always"],


### PR DESCRIPTION
Bad

```
expect(found).to.be.object;
```

Correct

```
expect(found).to.be.object();
```

See [Beware of libraries that assert on property access](https://github.com/moll/js-must#asserting-on-property-access). We should use [dirty-chai](https://github.com/prodatakey/dirty-chai#why) plugin to fix chai API and get function checkers (`be.object()`) in addition to property checkers (`be.object`).

@superkhau @raymondfeng @strongloop/loopback-dev please review
