### PR TITLE
Add "es6" to the list of "env"

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -1,7 +1,8 @@
 {
   "env": {
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "es6": true
   },
   "parserOptions": {
     "ecmaVersion": 6


### PR DESCRIPTION
This configures eslint to recognize ES6 specific things, most notably a global variable `Promise`.

See https://github.com/eslint/eslint/issues/4085
> Since this is the first google result for "eslint promise is not defined" I feel like it would be helpful to explicitly state the solution to this error here:

> add "env": { "es6": true } to your .eslintrc.

See also https://github.com/strongloop/eslint-config-loopback/pull/14 which enabled ES6 parser.

@strongloop/loopback-dev PTAL