### PR TITLE
[SEMVER-MAJOR] func-call-spacing: never

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -22,6 +22,7 @@
     "computed-property-spacing": ["error", "never"],
     "eol-last": ["error", "unix"],
     "func-names": 0,
+    "func-call-spacing": ["error", "never"],
     "indent": ["error", 2, {"SwitchCase": 1}],
     "key-spacing": ["error", {"beforeColon": false, "afterColon": true,
       "mode": "strict"}],


### PR DESCRIPTION
Disallow spaces between the function name and the opening parenthesis
that calls it, see http://eslint.org/docs/rules/func-call-spacing

Correct:

    fn();

Incorrect:

    fn ();

    fn
    ();

I noticed we are not enforcing either style when back-porting a patch from LB 3.x to LB 2.x, because the rule is enforced in LB 2.x by jscs.

@superkhau @strongloop/loopback-devs PTAL 