### PR TITLE
[SEMVER-MAJOR] spaced-comment: always

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -49,6 +49,17 @@
     "space-before-function-paren": ["error", "never"],
     "space-in-parens": ["error", "never"],
     "space-infix-ops": ["error", {"int32Hint": false}],
+    "spaced-comment": ["error", "always", {
+      "line": {
+        "markers": ["/"],
+        "exceptions": ["-"]
+      },
+      "block": {
+        "balanced": true,
+        "markers": ["!"],
+        "exceptions": ["*"]
+      }
+    }],
     "strict": ["error", "global"]
   }
 }


### PR DESCRIPTION
Require a whitespace immediatelly after initial `//` or `/*` of a comment. This whitespace makes it easier to read text in comments. See http://eslint.org/docs/rules/spaced-comment

Correct:

```
// This is a comment with a whitespace at the beginning
/* This is a comment with a whitespace at the beginning */

/**
 * I am jsdoc
 */

//--------------
// Comment block
//--------------

/***************
 * Comment block
 ***************/

/*!
 * Comment block
 */

```

Incorrect:

```
//This is a comment with no whitespace at the beginning
/*This is a comment with no whitespace at the beginning */
/* This is a comment with whitespace at the beginning but not the end*/
```

@superkhau @strongloop/loopback-devs PTAL