### PR TITLE
[SEMVER-MAJOR] Enable no-redeclare

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -34,6 +34,7 @@
       "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\("}],
     "no-array-constructor": 2,
     "no-multiple-empty-lines": ["error", { "max": 1 }],
+    "no-redeclare": ["error"],
     "no-trailing-spaces": 2,
     "no-undef": "error",
     "object-curly-spacing": ["error", "never"],


### PR DESCRIPTION
### Description

Disallow variable redeclaration. In JavaScript, it’s possible to redeclare the same variable name using `var`. This can lead to confusion as to where the variable is actually declared and initialized.

See http://eslint.org/docs/rules/no-redeclare

#### Examples

Good:

    var a;
    if (cond) {
      a = 3;
      // ...
    } else {
      a = 10;
    }

Bad:

    if (cond) {
      var a = 3;
      // ...
    } else {
      var a = 10;
    }



#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
