### PR TITLE
Enable function-paren-newline rule

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -26,6 +26,7 @@
     "eol-last": ["error", "unix"],
     "func-names": 0,
     "func-call-spacing": ["error", "never"],
+    "function-paren-newline": ["error", "consistent"],
     "indent": ["error", 2, {"SwitchCase": 1}],
     "key-spacing": ["error", {"beforeColon": false, "afterColon": true,
       "mode": "strict"}],


### PR DESCRIPTION
### Description
Added linter rule for `function-paren-newline`. There are [several types of rules](https://eslint.org/docs/rules/function-paren-newline) `eslint` comes with out of the box. 

I have used `consistent` in the past just because of personal preference but using another rule option could better fit strongloops needs. Let me know what you guys think.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #28
- connect to strongloop/loopback-swagger#127

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)