### PR TITLE
Update "eslint-plugin-mocha" module to "^5.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/strongloop/eslint-config-loopback",
   "dependencies": {
-    "eslint-plugin-mocha": "^4.11.0"
+    "eslint-plugin-mocha": "^5.2.0"
   }
 }


### PR DESCRIPTION
### Description

- Solves warning thrown on `npm install`: "_eslint-plugin-mocha@4.12.1 requires a peer of eslint@^2.0.0 || ^3.0.0 || ^4.0.0 but none is installed. You must install peer dependencies yourself._"

- Avoids the need of installing  "eslint-plugin-mocha" on [Loopback repository](https://github.com/strongloop/loopback/blob/master/package.json#L75), as [Loopback's .eslintrc](https://github.com/strongloop/loopback/blob/master/.eslintrc) config extends "eslint-config-loopback".

#### Related issues

- close #32

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
