### PR TITLE
Enable async functions, disable "var", prefer "const" over "let"

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -47,6 +47,7 @@
     "no-redeclare": ["error"],
     "no-trailing-spaces": 2,
     "no-undef": "error",
+    "no-var": "error",
     "object-curly-spacing": ["error", "never"],
     "one-var": ["error", {
       "initialized": "never",
@@ -54,6 +55,7 @@
     }],
     "operator-linebreak": ["error", "after"],
     "padded-blocks": ["error", "never"],
+    "prefer-const": "error",
     "quotes": ["error", "single", "avoid-escape"],
     "semi-spacing": ["error", {"before": false, "after": true}],
     "semi": ["error", "always"],

--- a/eslint.json
+++ b/eslint.json
@@ -8,7 +8,7 @@
     "mocha"
   ],
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 2017
   },
   "rules": {
     "comma-dangle": ["error", "always-multiline"],
@@ -58,7 +58,11 @@
     "semi-spacing": ["error", {"before": false, "after": true}],
     "semi": ["error", "always"],
     "space-before-blocks": ["error", "always"],
-    "space-before-function-paren": ["error", "never"],
+    "space-before-function-paren": ["error", {
+        "anonymous": "never",
+        "named": "never",
+        "asyncArrow": "always"
+    }],
     "space-in-parens": ["error", "never"],
     "space-infix-ops": ["error", {"int32Hint": false}],
     "spaced-comment": ["error", "always", {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-loopback",
-  "version": "12.1.0",
+  "version": "13.0.0-1",
   "description": "ESLint configs for LoopBack projects.",
   "main": "eslint.json",
   "repository": {


### PR DESCRIPTION
This is a follow-up for https://github.com/strongloop/loopback-datasource-juggler/pull/1674 and https://github.com/strongloop/loopback-datasource-juggler/pull/1671.

- Enable ES2017 and async functions
- Enable no-var and prefer-const rules
