### PR TITLE
Add no-const-assign to error

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -8,13 +8,14 @@
     "mocha"
   ],
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2018
   },
   "rules": {
     "comma-dangle": ["error", "always-multiline"],
     "no-cond-assign": "error",
     "no-console": "off",
     "no-unused-expressions": "error",
+    "no-const-assign": "error",
 
     "array-bracket-spacing": ["error", "never"],
     "block-spacing": ["error", "always"],


### PR DESCRIPTION
### Description
- Bumps ecma version of the parser to 2018
- Adds `no-const-assign` rule to `error`

#### Related issues
- I can't believe const reassign is alright from loopbacks point of view https://github.com/strongloop/eslint-config-loopback/issues/35
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->


### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
